### PR TITLE
Update megasync-2.9.5.ebuild

### DIFF
--- a/net-misc/megasync/megasync-2.9.5.ebuild
+++ b/net-misc/megasync/megasync-2.9.5.ebuild
@@ -53,7 +53,7 @@ RDEPEND="${DEPEND}
 		sqlite? ( dev-db/sqlite:3 )
 		libsodium? ( dev-libs/libsodium )
 		zlib? ( sys-libs/zlib )
-		curl? ( net-misc/curl[ssl] )
+		curl? ( net-misc/curl[ssl,curl_ssl_openssl] )
 		freeimage? ( media-libs/freeimage )
 		readline? ( sys-libs/readline:0 )
 		nautilus? (


### PR DESCRIPTION
Megasync required curl with openssl support.
If curl built with some else ssl support, megasync client close immediately.
$ megasync --debug
17:52:19 (warn):  QT Warning: QSystemTrayIcon::setVisible: No Icon set
17:52:19 (fatal): cURL built without OpenSSL support. Aborting. (net.cpp:39)