### PR TITLE
Use `eapply_user` instead of `epatch_user`

### DIFF
--- a/app-editors/atom-bin/atom-bin-1.10.2.ebuild
+++ b/app-editors/atom-bin/atom-bin-1.10.2.ebuild
@@ -56,7 +56,7 @@ pkg_setup() {
 src_prepare(){
 	rm resources/app/apm/bin/node
 	rm resources/app/apm/bin/npm
-	epatch_user
+	eapply_user
 }
 
 src_install() {


### PR DESCRIPTION
As of EAPI 6 `eapply_user` replaces `epatch_user`

 * ERROR: app-editors/atom-bin-1.10.2::jorgicio failed (prepare phase):
 *   eapply_user (or default) must be called in src_prepare()!