### PR TITLE
guitarix2 waf doesn't work with python3

### DIFF
--- a/media-sound/guitarix2/guitarix2-0.36.1.ebuild
+++ b/media-sound/guitarix2/guitarix2-0.36.1.ebuild
@@ -6,7 +6,7 @@ EAPI="6"
 
 [[ "${PV}" = "9999" ]] && inherit git-r3
 
-PYTHON_COMPAT=( python{2_7,3_{3,4,5}} )
+PYTHON_COMPAT=( python2_7 )
 PYTHON_REQ_USE="threads(+)"
 inherit python-any-r1 waf-utils
 


### PR DESCRIPTION
Though there is waf-python3 available, guitarix doesn't seem to use it for now. When configuring, it ends with this:
```
Checking for jack session support        : Traceback (most recent call last):
  File "/var/calculate/tmp/portage/media-sound/guitarix2-0.36.1/work/guitarix-0.36.1/wafadmin3/Utils.py", line 446, in recurse
    txt=readf(file_path,m='rU')
  File "/var/calculate/tmp/portage/media-sound/guitarix2-0.36.1/work/guitarix-0.36.1/wafadmin3/Utils.py", line 409, in readf
    f=open(fname,m)
FileNotFoundError: [Errno 2] No such file or directory: '/var/calculate/tmp/portage/media-sound/guitarix2-0.36.1/work/guitarix-0.36.1/wscript_configure'
```