### PR TITLE
Reflect upstream renaming of the 128px icon

### DIFF
--- a/www-client/firefox-bin/firefox-bin-59.0.ebuild
+++ b/www-client/firefox-bin/firefox-bin-59.0.ebuild
@@ -87,7 +87,7 @@ src_install() {
 	declare MOZILLA_FIVE_HOME=/opt/${MOZ_PN}
 
 	local size sizes icon_path icon name
-	sizes="16 32 48"
+	sizes="16 32 48 128"
 	icon_path="${S}/browser/chrome/icons/default"
 	icon="${PN}"
 	name="Mozilla Firefox"
@@ -97,9 +97,6 @@ src_install() {
 		insinto "/usr/share/icons/hicolor/${size}x${size}/apps"
 		newins "${icon_path}/default${size}.png" "${icon}.png" || die
 	done
-	# The 128x128 icon has a different name
-	insinto /usr/share/icons/hicolor/128x128/apps
-	newins "${icon_path}/../../../icons/mozicon128.png" "${icon}.png" || die
 	# Install a 48x48 icon into /usr/share/pixmaps for legacy DEs
 	newicon "${S}"/browser/chrome/icons/default/default48.png ${PN}.png
 	domenu "${FILESDIR}"/${PN}.desktop


### PR DESCRIPTION
The name of the 128x128 pixel icon has been adjusted upstream. Without these changes the emerge leads to an error.


Regards