### PR TITLE
Fix setting locale

### DIFF
--- a/www-client/firefox-bin/firefox-bin-59.0.1.ebuild
+++ b/www-client/firefox-bin/firefox-bin-59.0.1.ebuild
@@ -121,10 +121,10 @@ src_install() {
 	# Install language packs
 	mozlinguas_src_install
 
-	local LANG=${linguas%% *}
+	local LANG=${LINGUAS%% *}
 	if [[ -n ${LANG} && ${LANG} != "en" ]]; then
 		elog "Setting default locale to ${LANG}"
-		echo "pref(\"general.useragent.locale\", \"${LANG}\");" \
+		echo "pref(\"intl.locale.requested\", \"${LANG}\");" \
 			>> "${ED}${MOZILLA_FIVE_HOME}"/defaults/pref/${PN}-prefs.js || \
 			die "sed failed to change locale"
 	fi


### PR DESCRIPTION
two changes here...

1. changed LINGUAS to uppercase (as per https://wiki.gentoo.org/wiki/Localization/Guide/de#LINGUAS; not quite sure about this. How has this ever worked?)

2. "general.useragent.locale" has been superseded by "intl.locale.requested" in Firefox 59


Regards